### PR TITLE
tests: disable network calls to ensure hermetic tests

### DIFF
--- a/__tests__/createOrUpdateIssue.test.ts
+++ b/__tests__/createOrUpdateIssue.test.ts
@@ -40,6 +40,9 @@ function atLeastObject(matcher: {
 }
 
 describe('createOrUpdateIssue', () => {
+  // disable live network connections
+  nock.disableNetConnect()
+
   // supress github actions commands inside tests
   beforeEach(() => process.stdout.write('::stop-commands::running-tests\n'))
   afterEach(() => process.stdout.write('::running-tests::\n'))

--- a/__tests__/getConfig.test.ts
+++ b/__tests__/getConfig.test.ts
@@ -5,6 +5,9 @@ import * as yaml from 'js-yaml'
 import nock from 'nock'
 
 describe('getConfig', () => {
+  // disable live network connections
+  nock.disableNetConnect()
+
   // supress github actions commands inside tests
   beforeEach(() => process.stdout.write('::stop-commands::running-tests\n'))
   afterEach(() => process.stdout.write('::running-tests::\n'))

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -66,14 +66,12 @@ describe('integration', () => {
   test('runs a URL config', async () => {
     const baseEnv = getBaseEnv()
     baseEnv[getInputName(ActionInputs.CONFIG_URL)] =
-      'https://raw.githubusercontent.com/aperture-science-incorporated/.github/master/repolinter.json'
+      'http://test/repolinter.json'
 
     const {out, code} = await runAction(Object.assign({}, process.env, baseEnv))
 
     expect(code).not.toEqual(0)
-    expect(out).toContain(
-      'https://raw.githubusercontent.com/aperture-science-incorporated/.github/master/repolinter.json'
-    )
+    expect(out).toContain('http://test/repolinter.json')
     expect(out).not.toContain('undefined')
   })
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -26,6 +26,9 @@ describe('main', () => {
 
   jest.setTimeout(30000)
 
+  // disable live network connections
+  nock.disableNetConnect()
+
   beforeEach(() => {
     // reset process.env
     process.env = {}
@@ -289,11 +292,9 @@ describe('main', () => {
   test('runs a failing URL config', async () => {
     const configPath = path.resolve(__dirname, 'testconfig.json')
     process.env[getInputName(ActionInputs.CONFIG_URL)] =
-      'https://raw.githubusercontent.com/aperture-science-incorporated/.github/master/repolinter.json'
+      'http://test/repolinter.json'
 
-    nock('https://raw.githubusercontent.com')
-      .get('/aperture-science-incorporated/.github/master/repolinter.json')
-      .replyWithFile(200, configPath)
+    nock('http://test').get('/repolinter.json').replyWithFile(200, configPath)
 
     const expected = jsonFormatter.formatOutput(
       await lint(

--- a/__tests__/testconfig.json
+++ b/__tests__/testconfig.json
@@ -20,14 +20,6 @@
                     "nocase": true,
                     "hash": "c0b76cd474db37b060a909aba86a85f60381bbdd46ce1575dde2notarealhash"
                 }
-            },
-            "fix": {
-                "type": "file-create",
-                "options": {
-                    "file": "CODE_OF_CONDUCT.md",
-                    "replace": true,
-                    "text": { "url": "https://raw.githubusercontent.com/aperture-science-incorporated/.github/master/CODE_OF_CONDUCT.md" }
-                }
             }
         }
     }


### PR DESCRIPTION
Most tests are using mocked HTTP connections provided by nock, but a few
are still making live calls to GitHub.  Interestingly, those tests still
pass when there is no network connection, but it's better to prevent
them in the first place.

Steps to do that:
- For all test suites that are using nock, have nock disable all net
  connections.
- The integration test doesn't use nock, so instead just use a bogus
  config URL. This fetch fails obviously, but doesn't disturb the test
- Similarly use a bogus config URL for other tests, even if they are
  nocked. This is not strictly necessary, but makes clear that the
  actual URL isn't important.
- Remove the 'fix' config from testconfig.json. This prevents the
  integration test from trying to fetch that file.  This 'fix' also
  isn't really testing anything unique in the context of
  repolinter-action as far as I can tell.