### PR TITLE
ci: remove ubuntu-16.04 and remove whitespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,16 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - ubuntu-16.04
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
+
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
           node-version: '15'
-      
+
       - name: Cache NPM
         uses: actions/cache@v2
         with:
@@ -29,31 +28,30 @@ jobs:
 
       - name: Install Dependencies
         run: npm ci
-      
+
       - name: Lint
         run: npm run lint
-      
+
       - name: Typescript Build
         run: npm run build
-      
+
       - name: NCC Package
         run: npm run package
-      
+
       - name: Test
         run: npm run test
-  
+
   job-test-system:
     strategy:
       fail-fast: false
       matrix:
         os:
           - ubuntu-latest
-          - ubuntu-16.04
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
+
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -76,7 +74,7 @@ jobs:
       - name: Run Action (JSON)
         id: repolinter-json
         run: >
-          docker run -t 
+          docker run -t
           -v ${{ github.workspace }}:/github/workspace -w /github/workspace
           -e INPUT_DIRECTORY=/github/workspace
           -e INPUT_TOKEN=${{ github.token }}
@@ -90,18 +88,18 @@ jobs:
           -e GITHUB_RUN_NUMBER=${{ github.run_number }}
           -e GITHUB_ACTION=true
           ${{ github.repository }}:latest
-      
+
       - name: Verify Outputs
         env:
           DID_ERROR: ${{ steps.repolinter-json.outputs.errored }}
           DID_PASS: ${{ steps.repolinter-json.outputs.passed }}
         shell: bash
         run: '[ "$DID_ERROR" = "false" ] && [ "$DID_PASS" = "true" ]'
-      
+
       - name: Run Action (YAML)
         id: repolinter-yaml
         run: >
-          docker run -t 
+          docker run -t
           -v ${{ github.workspace }}:/github/workspace -w /github/workspace
           -e INPUT_DIRECTORY=/github/workspace
           -e INPUT_TOKEN=${{ github.token }}
@@ -115,7 +113,7 @@ jobs:
           -e GITHUB_RUN_NUMBER=${{ github.run_number }}
           -e GITHUB_ACTION=true
           ${{ github.repository }}:latest
-      
+
       - name: Verify Outputs
         env:
           DID_ERROR: ${{ steps.repolinter-yaml.outputs.errored }}
@@ -137,7 +135,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '15'
-      
+
       - name: Cache NPM
         uses: actions/cache@v2
         with:
@@ -145,10 +143,10 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      
+
       - name: Install Dependencies
         run: npm ci
-      
+
       - name: Build
         run: npm run build
 
@@ -165,7 +163,7 @@ jobs:
             @semantic-release/exec
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Cache Docker layers
         if: steps.semantic.outputs.new_release_published == 'true'
         uses: actions/cache@v2
@@ -174,7 +172,7 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      
+
       - name: Set up Docker Buildx
         if: steps.semantic.outputs.new_release_published == 'true'
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
ubuntu-16.04 was removed from GitHub actions on September 20, 2021.
https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/